### PR TITLE
Fix Newline vs. Carriage Return

### DIFF
--- a/src/main/java/edu/grinnell/csc207/util/Matrix.java
+++ b/src/main/java/edu/grinnell/csc207/util/Matrix.java
@@ -48,7 +48,7 @@ public interface Matrix<T> extends Cloneable {
     for (int i = 0; i < width; i++) {
       pen.print("+" + "-".repeat(cellWidth));
     } // for
-    pen.println("+");
+    pen.print("+\n");
   } // printRowSeparator(PrintWriter, int, int)
 
   /**
@@ -121,7 +121,7 @@ public interface Matrix<T> extends Cloneable {
       for (int col = 0; col < width; col++) {
         printCell(pen, String.format("%2d", col), cellWidth + 1);
       } // for
-      pen.println();
+      pen.print("\n");
     } // if
 
     for (int row = 0; row < height; row++) {
@@ -136,7 +136,7 @@ public interface Matrix<T> extends Cloneable {
         pen.print("|");
         printCell(pen, toString(matrix.get(row, col)), cellWidth);
       } // for col
-      pen.println("|");
+      pen.print("|\n");
     } // for row
     if (includeLabels) {
       pen.print(" ".repeat(4));


### PR DESCRIPTION
Currently the MatrixExperimentsTest.java -> matrixExperimentsAsTest() method returns failed even when the tests seem to be correctly outputting the right answer. This is due to the fact that println() outputs a [carriage return Unicode value](https://www.compart.com/en/unicode/U+000D) and not a Newline character. This commit fixes that issue.